### PR TITLE
Fix Looting Bots

### DIFF
--- a/LootingBots-SIT/utils/BotTypes.cs
+++ b/LootingBots-SIT/utils/BotTypes.cs
@@ -118,8 +118,8 @@ namespace LootingBots.Patch.Util
             // Unchecked to get around cast of usec/bear WildSpawnType added in AkiBotsPrePatcher
             unchecked
             {
-                WildSpawnType bear = (WildSpawnType)0x26;
-                WildSpawnType usec = (WildSpawnType)0x27;
+                WildSpawnType bear = (WildSpawnType)0x2A;
+                WildSpawnType usec = (WildSpawnType)0x29;
 
                 return wildSpawnType == bear || wildSpawnType == usec;
             }

--- a/MasterList.json
+++ b/MasterList.json
@@ -174,7 +174,7 @@
     "Author": "Skwizzy",
     "SupportedVersion": "1.9.8735.34855",
     "ModVersion": "1.1.4",
-    "PortVersion": "1.2.0",
+    "PortVersion": "1.3.0",
     "Description": "This mod aims to add more life to the bots by enhancing some EFT looting behaviors letting bots loot items, containers, and corpses during patrols. More features to come!",
     "ModUrl": "https://hub.sp-tarkov.com/files/file/1096-looting-bots/",
     "RequiresFiles": true,


### PR DESCRIPTION
The new assembly broke PMCs looting because we have WildSpawnTypes bear and usec hardcoded and they changed with the new release's assembly. If we hadn't had that chance conversation about it, I never woulda know where to look to fix this :)

Also thanks to Shibdib for noticing the issue and making for a good debugger :)