### PR TITLE
Add remote plugins patcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SIT_RemotePlugins"]
+	path = SIT_RemotePlugins
+	url = https://github.com/caellach/SIT_RemotePlugins.git

--- a/MasterList.json
+++ b/MasterList.json
@@ -336,5 +336,20 @@
       "ThatsLit-Release.dll"
     ],
     "ConfigFiles": []
+  },
+  {
+    "Name": "Remote Plugins",
+    "Author": "caellach",
+    "SupportedVersion": "1.10.8854.18454",
+    "ModVersion": "0.2.2",
+    "PortVersion": "1.0.0",
+    "Description": "Syncs client mods from the AKI Server. If you are running a server then see the READMEs on github for setup.",
+    "ModUrl": "https://github.com/caellach/SIT_RemotePlugins",
+    "RequiresFiles": true,
+    "PluginFiles": [],
+    "ConfigFiles": [],
+    "PatcherFiles": [
+       "RemotePlugins.dll"
+    ]
   }
 ]

--- a/MasterList.json
+++ b/MasterList.json
@@ -343,7 +343,7 @@
     "SupportedVersion": "1.10.8854.18454",
     "ModVersion": "0.2.2",
     "PortVersion": "1.0.0",
-    "Description": "Syncs client mods from the AKI Server. If you are running a server then see the READMEs on github for setup.",
+    "Description": "Syncs client mods from the AKI Server. Understand the risks before using. See the READMEs on github for setup.",
     "ModUrl": "https://github.com/caellach/SIT_RemotePlugins",
     "RequiresFiles": true,
     "PluginFiles": [],


### PR DESCRIPTION
Update the MasterList.json
Add SIT_RemotePlugins as a submodule at tag v0.2.3

The following is an example updated `SIT.Mod.Ports.Collection.zip` based on this repo's v2.4 release, the updated MasterList.json, and the most recent release DLL for RemotePlugins.

[SIT.Mod.Ports.Collection.zip](https://github.com/stayintarkov/SIT-Mod-Ports/files/14890508/SIT.Mod.Ports.Collection.zip)
