### PR TITLE
Fixed FU-Inertia to work on Tarkov 0.14.1.3.29351, SIT 1.10.8854.1845…

### DIFF
--- a/FU-Inertia-SIT/Plugin.cs
+++ b/FU-Inertia-SIT/Plugin.cs
@@ -156,7 +156,7 @@ namespace dvize.FUInertia
                 float totalWeight = (player.InteractablePlayer.Skills.StrengthBuffElite ? (inventoryController.Inventory.TotalWeightEliteSkill * Plugin.weightCarryingTotalMultiplier.Value)
                     : (inventoryController.Inventory.TotalWeight * Plugin.weightCarryingTotalMultiplier.Value));
 
-                Config4.InertiaSettings inertia = Singleton<Config4>.Instance.Inertia;
+                BackendConfigSettingsClass.InertiaSettings inertia = Singleton<BackendConfigSettingsClass>.Instance.Inertia;
                 //__instance.Inertia = __instance.CalculateValue(__instance.BaseInertiaLimits, totalWeight);
                 __instance.Inertia = 0f;
                 __instance.SprintAcceleration = inertia.SprintAccelerationLimits.InverseLerp(__instance.Inertia);
@@ -252,7 +252,7 @@ namespace dvize.FUInertia
         }
 
         [PatchPrefix]
-        private static bool Prefix(MovementContext __instance, float deltaTime, Player ____player, GClass701 ____averageRotationX)
+        private static bool Prefix(MovementContext __instance, float deltaTime, Player ____player, GClass709 ____averageRotationX)
         {
 
             bool inRaid = Singleton<AbstractGame>.Instance.InRaid;


### PR DESCRIPTION
Fixed FU-Inertia sources to work on new version.

Supports:
Tarkov 0.14.1.3.29351
SIT 1.10.8854.18454
AKI 3.8.0

Didn't check other versions.